### PR TITLE
Fix MCP client server path to use relative location

### DIFF
--- a/mcp_ollama_client.py
+++ b/mcp_ollama_client.py
@@ -2,6 +2,7 @@
 import json
 import subprocess
 import sys
+import os
 
 
 def send_msg(proc, obj):
@@ -43,10 +44,10 @@ def main():
     repo_path = sys.argv[3]
     months = int(sys.argv[4]) if len(sys.argv) > 4 else 6
 
-    server_cmd = [
-        sys.executable,
-        "/Users/yosefsaaid/dev/who-to-ask/who_to_ask_server.py",
-    ]
+    # Launch the MCP server using a path relative to this file so the script
+    # works outside the original developer's environment.
+    server_path = os.path.join(os.path.dirname(__file__), "who_to_ask_server.py")
+    server_cmd = [sys.executable, server_path]
     proc = subprocess.Popen(
         server_cmd,
         stdin=subprocess.PIPE,

--- a/my_mcp_client.py
+++ b/my_mcp_client.py
@@ -3,6 +3,7 @@ import subprocess
 import sys
 
 import ollama
+import os
 
 
 def send_msg(proc, obj):
@@ -35,10 +36,9 @@ def read_msg(proc):
 
 
 # ---- Launch MCP server ----
-server_cmd = [
-    "/Users/yosefsaaid/dev/who-to-ask/.venv/bin/python",
-    "/Users/yosefsaaid/dev/who-to-ask/who_to_ask_server.py",
-]
+# Use the current interpreter and resolve the server path relative to this file
+server_path = os.path.join(os.path.dirname(__file__), "who_to_ask_server.py")
+server_cmd = [sys.executable, server_path]
 proc = subprocess.Popen(
     server_cmd,
     stdin=subprocess.PIPE,


### PR DESCRIPTION
## Summary
- use relative path for `who_to_ask_server.py` in the MCP clients

## Testing
- `python -m py_compile mcp_ollama_client.py my_mcp_client.py who_to_ask_server.py who2ask_client.py`


------
https://chatgpt.com/codex/tasks/task_e_68a3efb6dd008332a803330ce425599f