### PR TITLE
Handle multi-hit snippet lookups with heuristics and tests

### DIFF
--- a/snippet_lookup.py
+++ b/snippet_lookup.py
@@ -1,0 +1,69 @@
+import os
+from difflib import SequenceMatcher
+from typing import Callable, List, Optional, Tuple
+
+
+def find_file_by_snippet(
+    snippet: str,
+    repo_path: str = ".",
+    prompt_user: bool = False,
+    input_func: Callable[[str], str] = input,
+) -> Optional[str]:
+    """Locate a file in ``repo_path`` containing ``snippet``.
+
+    If multiple files match, either prompt the user to choose one or select the
+    best match heuristically using :class:`difflib.SequenceMatcher` to measure
+    similarity (longest common subsequence ratio).
+
+    Args:
+        snippet: The snippet of text to search for.
+        repo_path: Directory tree to search.
+        prompt_user: If ``True`` and multiple matches are found, interactively
+            ask the user to choose a file. If ``False``, the best match is
+            selected automatically.
+        input_func: Function used to obtain user input. Useful for unit tests.
+
+    Returns:
+        The path of the matching file relative to ``repo_path`` or ``None`` if
+        no match is found.
+    """
+
+    repo_path = os.path.abspath(repo_path)
+    candidates: List[Tuple[str, str]] = []  # (path, content)
+
+    for root, dirs, files in os.walk(repo_path):
+        if ".git" in dirs:
+            dirs.remove(".git")
+        for name in files:
+            path = os.path.join(root, name)
+            try:
+                with open(path, "r", encoding="utf-8", errors="ignore") as fh:
+                    content = fh.read()
+            except OSError:
+                continue
+            if snippet in content:
+                candidates.append((path, content))
+
+    if not candidates:
+        return None
+
+    if len(candidates) == 1:
+        return candidates[0][0]
+
+    if prompt_user:
+        for idx, (path, _) in enumerate(candidates, 1):
+            print(f"{idx}: {os.path.relpath(path, repo_path)}")
+        while True:
+            try:
+                choice = int(input_func("Select the correct file: ")) - 1
+            except ValueError:
+                continue
+            if 0 <= choice < len(candidates):
+                return candidates[choice][0]
+
+    # Heuristic selection: pick file with highest similarity ratio
+    def score(item: Tuple[str, str]) -> float:
+        return SequenceMatcher(None, snippet, item[1]).ratio()
+
+    best_path, _ = max(candidates, key=score)
+    return best_path

--- a/tests/test_snippet_lookup.py
+++ b/tests/test_snippet_lookup.py
@@ -1,0 +1,26 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from snippet_lookup import find_file_by_snippet
+
+def test_single_match(tmp_path):
+    f1 = tmp_path / "file1.txt"
+    f1.write_text("hello world\\n")
+    (tmp_path / "file2.txt").write_text("nothing here\\n")
+
+    result = find_file_by_snippet("world", str(tmp_path))
+    assert result == str(f1)
+
+def test_no_match(tmp_path):
+    (tmp_path / "file1.txt").write_text("foo\\n")
+    result = find_file_by_snippet("bar", str(tmp_path))
+    assert result is None
+
+def test_multiple_matches_heuristic(tmp_path):
+    snippet = "print('hi')\n"
+    f1 = tmp_path / "a.py"
+    f1.write_text(snippet)
+    f2 = tmp_path / "b.py"
+    f2.write_text("# header\\n" + snippet + "# footer\\n")
+
+    result = find_file_by_snippet(snippet, str(tmp_path), prompt_user=False)
+    assert result == str(f1)


### PR DESCRIPTION
## Summary
- add `find_file_by_snippet` utility that prompts or heuristically selects when snippet appears in multiple files
- cover single, multiple, and no match scenarios in `tests/test_snippet_lookup.py`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3f8423e288332ab76af4c7dfa4263