### PR TITLE
feat: cache snippet searches and support ripgrep index

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,12 @@ python who2ask_client.py --model qwen3:4b --server-cmd "python who_to_ask_server
 ```
 
 The client will connect to the server and allow you to ask questions that leverage repository history.
+
+## Snippet search
+
+The server also exposes a `find_file_by_snippet` tool that searches the
+repository for a given code snippet. Results are cached in memory using a hash
+of the snippet so repeated lookups are fast. For large repositories you can
+prebuild a [ripgrep-all](https://github.com/phiresky/ripgrep-all) index and
+call the tool with `use_index=True` and `index_path` pointing to the index
+directory to leverage the prebuilt search index.

--- a/who_to_ask_server.py
+++ b/who_to_ask_server.py
@@ -1,7 +1,9 @@
 import collections
+import hashlib
 import os
 import re
 import shlex
+import shutil
 import subprocess
 import sys
 from datetime import datetime, timedelta
@@ -13,6 +15,9 @@ mcp = FastMCP("who-to-ask")
 print(
     f"[WHO-TO-ASK MCP] Server starting (pid={os.getpid()})", file=sys.stderr, flush=True
 )
+
+# Cache for snippet search results keyed by hash
+_snippet_cache: Dict[str, List[str]] = {}
 
 # ----------------------
 # Helper functions
@@ -119,6 +124,39 @@ def find_importers(file_path: str, repo_path: str, timeout_s: int = 20) -> List[
 # ----------------------
 # Tools
 # ----------------------
+
+
+@mcp.tool()
+def find_file_by_snippet(
+    snippet: str,
+    repo_path: str = ".",
+    use_index: bool = False,
+    index_path: str | None = None,
+) -> List[str]:
+    """Return lines ``file:line:match`` where snippet appears.
+
+    Results are cached by a hash of the snippet. When ``use_index`` is True and
+    ``ripgrep-all`` is available, a prebuilt index can be leveraged for faster
+    searches. ``index_path`` should point to the directory containing the
+    prebuilt index (defaults to ``<repo>/.rga``).
+    """
+
+    snippet_hash = hashlib.sha256(snippet.encode("utf-8")).hexdigest()
+    if snippet_hash in _snippet_cache:
+        return _snippet_cache[snippet_hash]
+
+    repo_path = os.path.abspath(repo_path)
+
+    if use_index and shutil.which("rga"):
+        index = index_path or os.path.join(repo_path, ".rga")
+        cmd = ["rga", "--prebuilt", index, snippet, repo_path]
+    else:
+        cmd = ["rg", "-n", snippet, repo_path]
+
+    out = _run(cmd, timeout_s=20)
+    results = out.splitlines() if out else []
+    _snippet_cache[snippet_hash] = results
+    return results
 
 
 @mcp.tool()


### PR DESCRIPTION
## Summary
- cache snippet search results by snippet hash
- add `find_file_by_snippet` tool with optional ripgrep-all index usage
- document snippet search tool and index support

## Testing
- `python -m py_compile who_to_ask_server.py`


------
https://chatgpt.com/codex/tasks/task_e_68a3f844d4fc8332a1e7923a24e93ab1