### PR TITLE
Normalize README.md to text

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+README.md text


### PR DESCRIPTION
## Summary
- Re-encoded README.md as UTF-8 text to ensure proper normalization.
- Added a gitattributes rule to force Git to treat README.md as text.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3fc99a6488332b6abbd47cb647ba3