### PR TITLE
Add simple local web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,16 @@ python who2ask_client.py --model qwen3:4b --server-cmd "python who_to_ask_server
 
 The client will connect to the server and allow you to ask questions that leverage repository history.
 
+### Web UI
+
+For a simple browser-based interface, run:
+
+```bash
+python web_ui.py
+```
+
+By default this will launch both the MCP server and a Gradio chat window at `http://localhost:7860` where you can ask questions interactively.
+
 ## Snippet search
 
 The server also exposes a `find_file_by_snippet` tool that searches the

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ mcp
 requests
 rich
 ollama
+gradio
+pytest

--- a/web_ui.py
+++ b/web_ui.py
@@ -1,0 +1,51 @@
+import asyncio
+import os
+import shlex
+from typing import List, Tuple
+
+import gradio as gr
+
+from who2ask_client import (
+    McpWrapper,
+    as_ollama_tools,
+    run_turn_with_tools,
+    SYSTEM_PROMPT,
+)
+
+MODEL = os.getenv("OLLAMA_MODEL", "qwen3:4b")
+SERVER_CMD = os.getenv("WHO2ASK_SERVER_CMD", "python who_to_ask_server.py")
+TIMEOUT = int(os.getenv("WHO2ASK_TIMEOUT", "120"))
+
+
+def build_messages(history: List[Tuple[str, str]], user_input: str):
+    messages = [{"role": "system", "content": SYSTEM_PROMPT}]
+    for user, assistant in history:
+        messages.append({"role": "user", "content": user})
+        messages.append({"role": "assistant", "content": assistant})
+    messages.append({"role": "user", "content": user_input})
+    return messages
+
+
+def respond(user_input, history):
+    async def _ask():
+        parts = shlex.split(SERVER_CMD)
+        cmd, args = parts[0], parts[1:]
+        async with McpWrapper(command=cmd, args=args) as mcp:
+            mcp_tools = await mcp.list_tools()
+            tools = as_ollama_tools(mcp_tools)
+            msgs = build_messages(history, user_input)
+            final, _ = await run_turn_with_tools(
+                MODEL, mcp, msgs, tools, timeout_s=TIMEOUT
+            )
+            return final
+
+    return asyncio.run(_ask())
+
+
+def main():
+    chat = gr.ChatInterface(respond, title="Who To Ask")
+    chat.launch()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `web_ui.py` to launch Who-to-Ask via a Gradio chat interface
- document web UI and update dependencies

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3fdb320388332ae956dc90e68cbe5