### PR TITLE
Reuse persistent MCP session in Gradio app

### DIFF
--- a/web_ui.py
+++ b/web_ui.py
@@ -1,7 +1,7 @@
 import asyncio
 import os
 import shlex
-from typing import List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import gradio as gr
 
@@ -17,6 +17,13 @@ SERVER_CMD = os.getenv("WHO2ASK_SERVER_CMD", "python who_to_ask_server.py")
 TIMEOUT = int(os.getenv("WHO2ASK_TIMEOUT", "120"))
 
 
+LOOP = asyncio.new_event_loop()
+asyncio.set_event_loop(LOOP)
+
+MCP: Optional[McpWrapper] = None
+TOOLS: List[Dict[str, Any]] = []
+
+
 def build_messages(history: List[Tuple[str, str]], user_input: str):
     messages = [{"role": "system", "content": SYSTEM_PROMPT}]
     for user, assistant in history:
@@ -28,23 +35,40 @@ def build_messages(history: List[Tuple[str, str]], user_input: str):
 
 def respond(user_input, history):
     async def _ask():
-        parts = shlex.split(SERVER_CMD)
-        cmd, args = parts[0], parts[1:]
-        async with McpWrapper(command=cmd, args=args) as mcp:
-            mcp_tools = await mcp.list_tools()
-            tools = as_ollama_tools(mcp_tools)
-            msgs = build_messages(history, user_input)
-            final, _ = await run_turn_with_tools(
-                MODEL, mcp, msgs, tools, timeout_s=TIMEOUT
-            )
-            return final
+        msgs = build_messages(history, user_input)
+        final, _ = await run_turn_with_tools(
+            MODEL, MCP, msgs, TOOLS, timeout_s=TIMEOUT
+        )
+        return final
 
-    return asyncio.run(_ask())
+    return LOOP.run_until_complete(_ask())
+
+
+async def init_mcp():
+    global MCP, TOOLS
+    parts = shlex.split(SERVER_CMD)
+    cmd, args = parts[0], parts[1:]
+    MCP = McpWrapper(command=cmd, args=args)
+    await MCP.__aenter__()
+    mcp_tools = await MCP.list_tools()
+    TOOLS = as_ollama_tools(mcp_tools)
+
+
+async def shutdown_mcp():
+    global MCP
+    if MCP is not None:
+        await MCP.__aexit__(None, None, None)
+        MCP = None
 
 
 def main():
+    LOOP.run_until_complete(init_mcp())
     chat = gr.ChatInterface(respond, title="Who To Ask")
-    chat.launch()
+    try:
+        chat.launch()
+    finally:
+        LOOP.run_until_complete(shutdown_mcp())
+        LOOP.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Initialize a single `McpWrapper` during startup and cache its tools
- Reuse the existing MCP session for each user request
- Cleanly shut down the MCP session when the Gradio app exits

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a40148523c8332aa7509fa6f373678